### PR TITLE
Fix bug with column name

### DIFF
--- a/app.R
+++ b/app.R
@@ -498,8 +498,7 @@ server <- function(input, output, session) {
     
     filename = "data.csv",
     content = function(file) {
-      write.csv(predictions() %>%
-                  select(-month), file, row.names = F)
+      write.csv(predictions(), file, row.names = F)
     }
   )
 }


### PR DESCRIPTION
You may wish to put the `select` back in but at the moment it refers to a column name that does not exist, so for ease I've removed it